### PR TITLE
お気に入り登録機能

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -289,3 +289,11 @@ h2.dish-name {
 .stats {
   margin: 5px 0;
 }
+
+// お気に入り
+.like-btn-unlike {
+  color: red;
+}
+.like-btn-like {
+  color: grey;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -297,3 +297,15 @@ h2.dish-name {
 .like-btn-like {
   color: grey;
 }
+
+a.like, a.unlike {
+  text-decoration: none;
+}
+
+.favorites {
+  list-style: none;
+  li {
+    padding: 10px 0;
+    border-top: 1px solid #e8e8e8 ;
+  }
+}

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,9 @@
+class FavoritesController < ApplicationController
+  before_action :logged_in_user
+
+  def create
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,8 +2,21 @@ class FavoritesController < ApplicationController
   before_action :logged_in_user
 
   def create
+    @dish = Dish.find(params[:dish_id])
+    @user = @dish.user
+    current_user.favorite(@dish)
+    respond_to do |format|
+      format.html { redirect_to request.referrer || root_url }
+      format.js
+    end
   end
 
   def destroy
+    @dish = Dish.find(params[:dish_id])
+    current_user.favorites.find_by(dish_id: @dish.id).destroy
+    respond_to do |format|
+      format.html { redirect_to request.referrer || root_url }
+      format.js
+    end
   end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,6 +1,10 @@
 class FavoritesController < ApplicationController
   before_action :logged_in_user
 
+  def index
+    @favorites = current_user.favorites
+  end
+
   def create
     @dish = Dish.find(params[:dish_id])
     @user = @dish.user

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,0 +1,2 @@
+module FavoritesHelper
+end

--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -1,5 +1,6 @@
 class Dish < ApplicationRecord
   belongs_to :user
+  has_many :favorites, dependent: :destroy
   default_scope -> { order(created_at: :desc) }
   mount_uploader :picture, PictureUploader
   validates :user_id, presence: true

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,4 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :dish
+end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,4 +1,6 @@
 class Favorite < ApplicationRecord
   belongs_to :user
   belongs_to :dish
+  validates :user_id, presence: true
+  validates :dish_id, presence: true 
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -3,5 +3,5 @@ class Favorite < ApplicationRecord
   belongs_to :dish
   default_scope -> { order(created_at: :desc) }
   validates :user_id, presence: true
-  validates :dish_id, presence: true 
+  validates :dish_id, presence: true
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,6 +1,7 @@
 class Favorite < ApplicationRecord
   belongs_to :user
   belongs_to :dish
+  default_scope -> { order(created_at: :desc) }
   validates :user_id, presence: true
   validates :dish_id, presence: true 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
                                    foreign_key: "followed_id",
                                    dependent: :destroy
   has_many :followers, through: :passive_relationships, source: :follower
+  has_many :favorites, dependent: :destroy
   attr_accessor :remember_token
   before_save :downcase_email
   validates :name, presence: true, length: { maximum: 50 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,6 +78,21 @@ class User < ApplicationRecord
     followers.include?(other_user)
   end
 
+  # 料理をお気に入りに登録する
+  def favorite(dish)
+    Favorite.create!(user_id: id, dish_id: dish.id)
+  end
+
+  # 料理をお気に入り解除する
+  def unfavorite(dish)
+    Favorite.find_by(user_id: id, dish_id: dish.id).destroy
+  end
+
+  # 現在のユーザーがお気に入り登録してたらtrueを返す
+  def favorite?(dish)
+    !Favorite.find_by(user_id: id, dish_id: dish.id).nil?
+  end
+
   private
 
   def downcase_email

--- a/app/views/dishes/_dish.html.erb
+++ b/app/views/dishes/_dish.html.erb
@@ -1,9 +1,11 @@
+<% @dish = dish %>
 <li id="dish-<%= dish.id %>">
   <%= link_to gravatar_for(dish.user, size: 50), dish.user %>
   <span class="name"><%= link_to dish.name, dish_path(dish) %></span>
   <span>
     <%= link_to((image_tag dish.picture.thumb200.url), dish_path(dish.id), class: 'dish-picture') if dish.picture.url.present? %>
   </span>
+  <%= render 'users/favorite_form' %>
   <span class="description"><%= dish.description %></span><br>
   <span class="required_time">所要時間：<%= dish.required_time %>分</span>
   <span class="popularity">人気度：<%= dish.popularity %></span><br>

--- a/app/views/dishes/show.html.erb
+++ b/app/views/dishes/show.html.erb
@@ -5,6 +5,7 @@
       <span class="picture">
         <%= link_to((image_tag @dish.picture.thumb400.url), dish_path(@dish.id), class: 'dish-picture') if @dish.picture.url.present? %>
       </span>
+      <%= render 'users/favorite_form' %>
     </div>
     <div class="col-md-8">
       <h2 class="dish-name"><%= @dish.name %></h2><br><br>

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -1,0 +1,14 @@
+<% @dish = Dish.find(favorite.dish_id) %>
+<% user = @dish.user %>
+<li id="favorite-<%= favorite.id %>">
+  <div class="row favorite-dish">
+    <div class="col-md-2">
+      <%= link_to((image_tag @dish.picture.url), dish_path(@dish), class: 'dish-picture') %>
+    </div>
+    <div class="col-md-7">
+      <p><%= link_to @dish.name, dish_path(@dish) %></p>
+      <p><%= @dish.description %></p>
+      <p class="cook-user">cooked by <%= link_to user.name, user_path(user) %></p>
+    </div>
+  </div>
+</li>

--- a/app/views/favorites/create.js.erb
+++ b/app/views/favorites/create.js.erb
@@ -1,0 +1,1 @@
+$("#favorite-<%= @dish.id %>").html("<%= escape_javascript(render('users/unfavorite')) %>");

--- a/app/views/favorites/destroy.js.erb
+++ b/app/views/favorites/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#favorite-<%= @dish.id %>").html("<%= escape_javascript(render('users/favorite')) %>");

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,0 +1,12 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <h3>お気に入り (<%= @favorites.count %>)</h3>
+    </div>
+  </div>
+  <% if @favorites.present? %>
+    <ol class="favorites">
+      <%= render @favorites %>
+    </ol>
+  <% end %>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,6 +5,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li><%= link_to 'ディッシュメモとは？', about_path %></li>
         <% if logged_in? %>
+          <li><%= link_to 'お気に入り', favorites_path %></li>
           <li><%= link_to 'ユーザー一覧', users_path %></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">

--- a/app/views/layouts/_rails_default.html.erb
+++ b/app/views/layouts/_rails_default.html.erb
@@ -4,3 +4,5 @@
 <%= stylesheet_link_tag    'application', media: 'all',
                            'data-turbolinks-track': 'reload' %>
 <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+
+<script src="https://kit.fontawesome.com/84eeecacff.js" crossorigin="anonymous"></script>

--- a/app/views/users/_favorite.html.erb
+++ b/app/views/users/_favorite.html.erb
@@ -1,0 +1,6 @@
+<%= link_to "/favorites/#{@dish.id}/create",
+            method: :post,
+            class: 'like',
+            remote: true do %>
+  <div class="like-btn-like"><i class="fa fa-heart"></i> お気に入りに登録する</div>
+<% end %>

--- a/app/views/users/_favorite_form.html.erb
+++ b/app/views/users/_favorite_form.html.erb
@@ -1,0 +1,7 @@
+<div id="favorite-<%= @dish.id %>">
+  <% if !current_user.nil? && current_user.favorite?(@dish) %>
+    <%= render 'users/unfavorite' %>
+  <% else %>
+    <%= render 'users/favorite' %>
+  <% end %>
+</div>

--- a/app/views/users/_unfavorite.html.erb
+++ b/app/views/users/_unfavorite.html.erb
@@ -1,0 +1,6 @@
+<%= link_to "/favorites/#{@dish.id}/destroy",
+            method: :delete,
+            class: 'unlike',
+            remote: true do %>
+  <div class="like-btn-unlike"><i class="fa fa-heart"></i> お気に入りに登録済み</div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,6 @@ Rails.application.routes.draw do
   end
   resources :dishes
   resources :relationships, only: [:create, :destroy]
+  post   "favorites/:dish_id/create"  => "favorites#create"
+  delete "favorites/:dish_id/destroy" => "favorites#destroy"
  end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   end
   resources :dishes
   resources :relationships, only: [:create, :destroy]
+  get :favorites, to: 'favorites#index'
   post   "favorites/:dish_id/create"  => "favorites#create"
   delete "favorites/:dish_id/destroy" => "favorites#destroy"
  end

--- a/db/migrate/20210608132047_create_favorites.rb
+++ b/db/migrate/20210608132047_create_favorites.rb
@@ -1,0 +1,11 @@
+class CreateFavorites < ActiveRecord::Migration[5.2]
+  def change
+    create_table :favorites do |t|
+      t.integer :user_id
+      t.integer :dish_id
+
+      t.timestamps
+    end
+    add_index :favorites, [:user_id, :dish_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_08_073504) do
+ActiveRecord::Schema.define(version: 2021_06_08_132047) do
 
   create_table "dishes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -27,6 +27,14 @@ ActiveRecord::Schema.define(version: 2021_06_08_073504) do
     t.string "picture"
     t.index ["user_id", "created_at"], name: "index_dishes_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_dishes_on_user_id"
+  end
+
+  create_table "favorites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "dish_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "dish_id"], name: "index_favorites_on_user_id_and_dish_id", unique: true
   end
 
   create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :favorite do
+    user_id 1
+    dish_id 1
+  end
+end

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :favorite do
-    user_id 1
-    dish_id 1
+    association :dish
+    association :user
   end
 end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Favorite, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,5 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Favorite, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let!(:favorite) { create(:favorite) }
+
+  it "favoriteインスタンスが有効であること" do
+    expect(favorite).to be_valid
+  end
+
+  it "user_idがnilの場合、無効であること" do
+    favorite.user_id = nil
+    expect(favorite).not_to be_valid
+  end
+
+  it "dish_idがnilの場合、無効であること" do
+    favorite.dish_id = nil
+    expect(favorite).not_to be_valid
+  end
 end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe "お気に入り登録機能", type: :request do
+  let(:user) { create(:user) }
+  let(:dish) { create(:dish) }
+
+  context "お気に入り登録処理" do
+    context "ログインしていない場合" do
+      it "お気に入り登録は実行できず、ログインページへリダイレクトすること" do
+        expect {
+          post "/favorites/#{dish.id}/create"
+        }.not_to change(Favorite, :count)
+        expect(response).to redirect_to login_path
+      end
+
+      it "お気に入り解除は実行できず、ログインページへリダイレクトすること" do
+        expect {
+          delete "/favorites/#{dish.id}/destroy"
+        }.not_to change(Favorite, :count)
+        expect(response).to redirect_to login_path
+      end
+    end
+  end
+end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -5,6 +5,38 @@ RSpec.describe "お気に入り登録機能", type: :request do
   let(:dish) { create(:dish) }
 
   context "お気に入り登録処理" do
+    context "ログインしている場合" do
+      before do
+        login_for_request(user)
+      end
+
+      it "料理のお気に入り登録ができること" do
+        expect {
+          post "/favorites/#{dish.id}/create"
+        }.to change(user.favorites, :count).by(1)
+      end
+
+      it "料理のAjaxによるお気に入り登録ができること" do
+        expect {
+          post "/favorites/#{dish.id}/create", xhr: true
+        }.to change(user.favorites, :count).by(1)
+      end
+
+      it "料理のお気に入り解除ができること" do
+        user.favorite(dish)
+        expect {
+          delete "/favorites/#{dish.id}/destroy"
+        }.to change(user.favorites, :count).by(-1)
+      end
+
+      it "料理のAjaxによるお気に入り解除ができること" do
+        user.favorite(dish)
+        expect {
+          delete "/favorites/#{dish.id}/destroy", xhr: true
+        }.to change(user.favorites, :count).by(-1)
+      end
+    end
+
     context "ログインしていない場合" do
       it "お気に入り登録は実行できず、ログインページへリダイレクトすること" do
         expect {

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -4,6 +4,25 @@ RSpec.describe "お気に入り登録機能", type: :request do
   let(:user) { create(:user) }
   let(:dish) { create(:dish) }
 
+  context "お気に入り一覧ページの表示" do
+    context "ログインしている場合" do
+      it "レスポンスが正常に表示されること" do
+        login_for_request(user)
+        get favorites_path
+        expect(response).to have_http_status "200"
+        expect(response).to render_template('favorites/index')
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "ログイン画面にリダイレクトすること" do
+        get favorites_path
+        expect(response).to have_http_status "302"
+        expect(response).to redirect_to login_path
+      end
+    end
+  end
+
   context "お気に入り登録処理" do
     context "ログインしている場合" do
       before do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Users", type: :system do
   let!(:user) { create(:user) }
   let!(:admin_user) { create(:user, :admin) }
   let!(:other_user) { create(:user) }
+  let!(:dish) { create(:dish, user: user) }
 
   describe "ユーザー一覧ページ" do
     context "管理者ユーザーの場合" do
@@ -172,6 +173,20 @@ RSpec.describe "Users", type: :system do
         expect(page).to have_button 'フォロー中'
         click_button 'フォロー中'
         expect(page).to have_button 'フォローする'
+      end
+    end
+
+    context "お気に入り登録/解除" do
+      before do
+        login_for_system(user)
+      end
+
+      it "料理のお気に入り登録/解除ができること" do
+        expect(user.favorite?(dish)).to be_falsey
+        user.favorite(dish)
+        expect(user.favorite?(dish)).to be_truthy
+        user.unfavorite(dish)
+        expect(user.favorite?(dish)).to be_falsey
       end
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -188,6 +188,42 @@ RSpec.describe "Users", type: :system do
         user.unfavorite(dish)
         expect(user.favorite?(dish)).to be_falsey
       end
+
+      it "トップページからお気に入り登録/解除ができること", js: true do
+        visit root_path
+        link = find('.like')
+        expect(link[:href]).to include "/favorites/#{dish.id}/create"
+        link.click
+        link = find('.unlike')
+        expect(link[:href]).to include "/favorites/#{dish.id}/destroy"
+        link.click
+        link = find('.like')
+        expect(link[:href]).to include "/favorites/#{dish.id}/create"
+      end
+
+      it "ユーザー個別ページからお気に入り登録/解除ができること", js: true do
+        visit user_path(user)
+        link = find('.like')
+        expect(link[:href]).to include "/favorites/#{dish.id}/create"
+        link.click
+        link = find('.unlike')
+        expect(link[:href]).to include "/favorites/#{dish.id}/destroy"
+        link.click
+        link = find('.like')
+        expect(link[:href]).to include "/favorites/#{dish.id}/create"
+      end
+
+      it "料理個別ページからお気に入り登録/解除ができること", js: true do
+        visit dish_path(dish)
+        link = find('.like')
+        expect(link[:href]).to include "/favorites/#{dish.id}/create"
+        link.click
+        link = find('.unlike')
+        expect(link[:href]).to include "/favorites/#{dish.id}/destroy"
+        link.click
+        link = find('.like')
+        expect(link[:href]).to include "/favorites/#{dish.id}/create"
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #8 
# What
- dishmemoのお気に入り登録機能を実装する
- rubocopによるコード自動修正を行う
- RSpecによる各種テストを行う

# Why
- 投稿された料理をユーザーがお気に入り登録、お気に入り解除できるようにするため
- お気にり登録した料理情報を確認できるようにするため