### PR TITLE
リスト登録機能

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -363,3 +363,23 @@ li.new_notification > a > span {
   color: grey;
   margin: 10px 0;
 }
+
+a.list, a.unlist {
+  text-decoration: none;
+}
+
+.lists {
+  list-style: none;
+  li {
+    padding: 10px 0;
+    border-top: 1px solid #e8e8e8 ;
+  }
+}
+
+.list-message {
+  font-size: 16px;
+}
+
+.list-dish-description {
+  margin-bottom: 20px;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -352,3 +352,14 @@ a.like, a.unlike {
 li.new_notification > a > span {
   color: red;
 }
+
+//// リスト ////
+.list-btn-unlist {
+  color: red;
+  margin: 10px 0;
+}
+
+.list-btn-list {
+  color: grey;
+  margin: 10px 0;
+}

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -5,8 +5,22 @@ class ListsController < ApplicationController
   end
 
   def create
+    @dish = Dish.find(params[:dish_id])
+    @user = @dish.user
+    current_user.list(@dish)
+    respond_to do |format|
+      format.html { redirect_to request.referrer || root_url }
+      format.js
+    end
   end
 
   def destroy
+    list = List.find(params[:list_id])
+    @dish = list.dish
+    list.destroy
+    respond_to do |format|
+      format.html { redirect_to request.referrer || root_url }
+      format.js
+    end
   end
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -2,6 +2,7 @@ class ListsController < ApplicationController
   before_action :logged_in_user
 
   def index
+    @lists = current_user.lists
   end
 
   def create

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,0 +1,12 @@
+class ListsController < ApplicationController
+  before_action :logged_in_user
+
+  def index
+  end
+
+  def create
+  end
+
+  def destroy
+  end
+end

--- a/app/helpers/lists_helper.rb
+++ b/app/helpers/lists_helper.rb
@@ -1,0 +1,2 @@
+module ListsHelper
+end

--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -2,6 +2,7 @@ class Dish < ApplicationRecord
   belongs_to :user
   has_many :favorites, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :lists, dependent: :destroy
   default_scope -> { order(created_at: :desc) }
   mount_uploader :picture, PictureUploader
   validates :user_id, presence: true

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,0 +1,2 @@
+class List < ApplicationRecord
+end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,2 +1,8 @@
 class List < ApplicationRecord
+  belongs_to :user
+  belongs_to :dish
+  default_scope -> { order(created_at: :desc) }
+  validates :user_id, presence: true
+  validates :dish_id, presence: true
+  validates :from_user_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   has_many :followers, through: :passive_relationships, source: :follower
   has_many :favorites, dependent: :destroy
   has_many :notifications, dependent: :destroy
+  has_many :lists, dependent: :destroy
   attr_accessor :remember_token
   before_save :downcase_email
   validates :name, presence: true, length: { maximum: 50 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,6 +95,21 @@ class User < ApplicationRecord
     !Favorite.find_by(user_id: id, dish_id: dish.id).nil?
   end
 
+  # 料理をリストに登録する
+  def list(dish)
+    List.create!(user_id: dish.user_id, dish_id: dish.id, from_user_id: id)
+  end
+
+  # 料理をリストから解除する
+  def unlist(list)
+    list.destroy
+  end
+
+  # 現在のユーザーがリスト登録してたらtrueを返す
+  def list?(dish)
+    !List.find_by(dish_id: dish.id, from_user_id: id).nil?
+  end
+
   private
 
   def downcase_email

--- a/app/views/dishes/_dish.html.erb
+++ b/app/views/dishes/_dish.html.erb
@@ -6,6 +6,7 @@
     <%= link_to((image_tag dish.picture.thumb200.url), dish_path(dish.id), class: 'dish-picture') if dish.picture.url.present? %>
   </span>
   <%= render 'users/favorite_form' %>
+  <%= render 'users/list_form' %>
   <span class="description"><%= dish.description %></span><br>
   <span class="required_time">所要時間：<%= dish.required_time %>分</span>
   <span class="popularity">人気度：<%= dish.popularity %></span><br>

--- a/app/views/dishes/show.html.erb
+++ b/app/views/dishes/show.html.erb
@@ -7,6 +7,7 @@
         <%= link_to((image_tag @dish.picture.thumb400.url), dish_path(@dish.id), class: 'dish-picture') if @dish.picture.url.present? %>
       </span>
       <%= render 'users/favorite_form' %>
+      <%= render 'users/list_form' %>
     </div>
     <div class="col-md-8">
       <h2 class="dish-name"><%= @dish.name %></h2><br><br>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,6 +13,7 @@
           <%= link_to notifications_path do %><span>通知</span><% end %>
           </li>
           <li><%= link_to 'お気に入り', favorites_path %></li>
+          <li><%= link_to '作る予定リスト', lists_path %></li>
           <li><%= link_to 'ユーザー一覧', users_path %></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">

--- a/app/views/lists/_list.html.erb
+++ b/app/views/lists/_list.html.erb
@@ -1,0 +1,28 @@
+<% @list = list %>
+<% @dish = Dish.find(list.dish_id) %>
+<% user = User.find(list.from_user_id) %>
+<li id="list-<%= @dish.id %>">
+  <div class="list-dish">
+    <p><%= list.created_at.strftime("%Y/%m/%d(%a) %H:%M") %> </p>
+    <% if list.user_id == list.from_user_id %>
+      <p class="list-message">この料理を作る予定リストに追加しました。</p>
+    <% else %>
+      <p class="list-message"><%= link_to user.name, user_path(user) %>さんがこの料理に食べたいリクエストをしました。</p>
+    <% end %>
+  </div>
+  <div class="row">
+    <div class="col-md-2">
+      <%= link_to((image_tag @dish.picture.url), dish_path(@dish), class: 'dish-picture') %>
+    </div>
+    <div class="col-md-7">
+      <p><%= link_to @dish.name, dish_path(@dish) %></p>
+      <p class="list-dish-description"><%= @dish.description %></p>
+    </div>
+    <div class="col-md-3">
+      <%= link_to "リストから削除", "/lists/#{list.id}/destroy",
+                             method: :delete,
+                             class: "unlist",
+                             data: { confirm: "本当にリストから削除しますか？" } %>
+    </div>
+  </div>
+</li>

--- a/app/views/lists/create.js.erb
+++ b/app/views/lists/create.js.erb
@@ -1,0 +1,1 @@
+$("#list-<%= @dish.id %>").html("<%= escape_javascript(render('users/unlist')) %>");

--- a/app/views/lists/destroy.js.erb
+++ b/app/views/lists/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#list-<%= @dish.id %>").html("<%= escape_javascript(render('users/list')) %>");

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Lists#index</h1>
+<p>Find me in app/views/lists/index.html.erb</p>

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -1,2 +1,12 @@
-<h1>Lists#index</h1>
-<p>Find me in app/views/lists/index.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <h3>作る予定リスト (<%= @lists.count %>)</h3>
+    </div>
+  </div>
+  <% if @lists.present? %>
+    <ol class="lists">
+      <%= render @lists %>
+    </ol>
+  <% end %>
+</div>

--- a/app/views/users/_list.html.erb
+++ b/app/views/users/_list.html.erb
@@ -1,0 +1,10 @@
+<%= link_to "/lists/#{@dish.id}/create",
+            method: :post,
+            class: 'list',
+            remote: true do %>
+  <% if current_user == @dish.user %>
+    <div class="list-btn-list"><i class="fas fa-list-alt"></i> 作る予定リストに追加する</div>
+  <% else %>
+    <div class="list-btn-list"><i class="fas fa-utensils"></i> 食べたいリクエストを送る</div>
+  <% end %>
+<% end %>

--- a/app/views/users/_list_form.html.erb
+++ b/app/views/users/_list_form.html.erb
@@ -1,0 +1,7 @@
+<div id="list-<%= @dish.id %>" class="list-button">
+  <% if !current_user.nil? && current_user.list?(@dish) %>
+    <%= render 'users/unlist' %>
+  <% else %>
+    <%= render 'users/list' %>
+  <% end %>
+</div>

--- a/app/views/users/_unlist.html.erb
+++ b/app/views/users/_unlist.html.erb
@@ -1,0 +1,11 @@
+<% list = List.find_by(dish_id: @dish.id) %>
+<%= link_to "/lists/#{list.id}/destroy",
+            method: :delete,
+            class: 'unlist',
+            remote: true do %>
+  <% if current_user == @dish.user %>
+    <div class="list-btn-unlist"><i class="fas fa-list-alt"></i> 作る予定リストに追加済み</div>
+  <% else %>
+    <div class="list-btn-unlist"><i class="fas fa-utensils"></i> 食べたいリクエスト済み</div>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,4 +18,7 @@ Rails.application.routes.draw do
   delete "favorites/:dish_id/destroy" => "favorites#destroy"
   resources :comments, only: [:create, :destroy]
   resources :notifications, only: :index
+  get :lists, to: 'lists#index'
+  post   "lists/:dish_id/create"  => "lists#create"
+  delete "lists/:list_id/destroy" => "lists#destroy"
  end

--- a/db/migrate/20210609093046_create_lists.rb
+++ b/db/migrate/20210609093046_create_lists.rb
@@ -1,0 +1,12 @@
+class CreateLists < ActiveRecord::Migration[5.2]
+  def change
+    create_table :lists do |t|
+      t.integer :user_id
+      t.integer :dish_id
+      t.integer :from_user_id
+
+      t.timestamps
+    end
+    add_index :lists, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_09_070358) do
+ActiveRecord::Schema.define(version: 2021_06_09_093046) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "dish_id"
@@ -45,6 +45,15 @@ ActiveRecord::Schema.define(version: 2021_06_09_070358) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id", "dish_id"], name: "index_favorites_on_user_id_and_dish_id", unique: true
+  end
+
+  create_table "lists", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "dish_id"
+    t.integer "from_user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_lists_on_user_id"
   end
 
   create_table "notifications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/factories/lists.rb
+++ b/spec/factories/lists.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :list do
-    user_id 1
-    dish_id 1
-    from_user_id 1
+    from_user_id { 1 }
+    association :user
+    association :dish
   end
 end

--- a/spec/factories/lists.rb
+++ b/spec/factories/lists.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :list do
+    user_id 1
+    dish_id 1
+    from_user_id 1
+  end
+end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe List, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -1,5 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe List, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let!(:list) { create(:list) }
+
+  it "listインスタンスが有効であること" do
+    expect(list).to be_valid
+  end
+
+  it "user_idがnilの場合、無効であること" do
+    list.user_id = nil
+    expect(list).not_to be_valid
+  end
+
+  it "dish_idがnilの場合、無効であること" do
+    list.dish_id = nil
+    expect(list).not_to be_valid
+  end
+
+  it "from_user_idがnilの場合、無効であること" do
+    list.from_user_id = nil
+    expect(list).not_to be_valid
+  end
 end

--- a/spec/requests/lists_spec.rb
+++ b/spec/requests/lists_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe "リスト登録機能", type: :request do
   let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:dish) { create(:dish, user: other_user) }
 
   context "リスト一覧ページの表示" do
     context "ログインしている場合" do
@@ -17,6 +19,48 @@ RSpec.describe "リスト登録機能", type: :request do
       it "ログイン画面にリダイレクトすること" do
         get lists_path
         expect(response).to have_http_status "302"
+        expect(response).to redirect_to login_path
+      end
+    end
+  end
+
+  context "リスト登録/解除機能" do
+    context "ログインしている場合" do
+      before do
+        login_for_request(user)
+      end
+
+      it "料理のリスト登録/解除ができること" do
+        expect {
+          post "/lists/#{dish.id}/create"
+        }.to change(other_user.lists, :count).by(1)
+        expect {
+          delete "/lists/#{List.first.id}/destroy"
+        }.to change(other_user.lists, :count).by(-1)
+      end
+
+      it "料理のAjaxによるリスト登録/解除ができること" do
+        expect {
+          post "/lists/#{dish.id}/create", xhr: true
+        }.to change(other_user.lists, :count).by(1)
+        expect {
+          delete "/lists/#{List.first.id}/destroy", xhr: true
+        }.to change(other_user.lists, :count).by(-1)
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "リスト登録は実行できず、ログインページへリダイレクトすること" do
+        expect {
+          post "/lists/#{dish.id}/create"
+        }.not_to change(List, :count)
+        expect(response).to redirect_to login_path
+      end
+
+      it "リスト解除は実行できず、ログインページへリダイレクトすること" do
+        expect {
+          delete "/lists/#{dish.id}/destroy"
+        }.not_to change(List, :count)
         expect(response).to redirect_to login_path
       end
     end

--- a/spec/requests/lists_spec.rb
+++ b/spec/requests/lists_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe "リスト登録機能", type: :request do
+  let(:user) { create(:user) }
+
+  context "リスト一覧ページの表示" do
+    context "ログインしている場合" do
+      it "レスポンスが正常に表示されること" do
+        login_for_request(user)
+        get lists_path
+        expect(response).to have_http_status "200"
+        expect(response).to render_template('lists/index')
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "ログイン画面にリダイレクトすること" do
+        get lists_path
+        expect(response).to have_http_status "302"
+        expect(response).to redirect_to login_path
+      end
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -249,4 +249,53 @@ RSpec.describe "Users", type: :system do
       end
     end
   end
+
+  context "リスト登録/解除" do
+    before do
+      login_for_system(user)
+    end
+
+    it "料理のお気に入り登録/解除ができること" do
+      expect(user.list?(dish)).to be_falsey
+      user.list(dish)
+      expect(user.list?(dish)).to be_truthy
+      user.unlist(List.first)
+      expect(user.list?(dish)).to be_falsey
+    end
+
+    it "トップページからリスト登録/解除ができること", js: true do
+      visit root_path
+      link = find('.list')
+      expect(link[:href]).to include "/lists/#{dish.id}/create"
+      link.click
+      link = find('.unlist')
+      expect(link[:href]).to include "/lists/#{List.first.id}/destroy"
+      link.click
+      link = find('.list')
+      expect(link[:href]).to include "/lists/#{dish.id}/create"
+    end
+
+    it "ユーザー個別ページからリスト登録/解除ができること", js: true do
+      visit user_path(user)
+      link = find('.list')
+      expect(link[:href]).to include "/lists/#{dish.id}/create"
+      link.click
+      link = find('.unlist')
+      expect(link[:href]).to include "/lists/#{List.first.id}/destroy"
+      link.click
+      link = find('.list')
+      expect(link[:href]).to include "/lists/#{dish.id}/create"
+    end
+
+    it "料理個別ページからリスト登録/解除ができること", js: true do
+      link = find('.list')
+      expect(link[:href]).to include "/lists/#{dish.id}/create"
+      link.click
+      link = find('.unlist')
+      expect(link[:href]).to include "/lists/#{List.first.id}/destroy"
+      link.click
+      link = find('.list')
+      expect(link[:href]).to include "/lists/#{dish.id}/create"
+    end
+  end
 end


### PR DESCRIPTION
Closes #12 
# What
- dishmemoのリスト登録機能を実装する
- rubocopによるコード自動修正を行う
- RSpecによる各種テストを行う

# Why
- 料理を投稿したユーザーが「作る予定」リストに料理を登録できるようにするため
- 料理を投稿したユーザーに対して「食べたいリクエスト」として別のユーザーからもリストに料理を登録できるようにするため
- 料理を投稿したユーザーがリスト登録した料理と別のユーザーからリスト登録された料理を確認できるようにするため

※rubocop済み