### PR TITLE
AWS/EC2のDB設定

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,5 +50,6 @@ test:
 production:
   <<: *default
   database: dishmemo_production
-  username: dishmemo
-  password: <%= ENV['DISHMEMO_DATABASE_PASSWORD'] %>
+  username: root
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
Closes #47 
# What
- dishmemoのAWS/EC2でのDB設定を行う
- rubocopによるコード自動修正を行う

# Why
- 本番環境であるAWS/EC2内でmysqlを使用できるようにするため

※rubocop済み