### PR TITLE
AWS/EC2へのデプロイ設定(修正4・Nginx導入)

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -11,7 +11,7 @@ working_directory app_path
 pid "#{app_path}/tmp/pids/unicorn.pid"
 
 #ポート番号を指定
-listen 3000
+listen "#{app_path}/tmp/sockets/unicorn.sock"
 
 #エラーのログを記録するファイルを指定
 stderr_path "#{app_path}/log/unicorn.stderr.log"


### PR DESCRIPTION
# What
- dishmemoをAWS/EC2へデプロイするための設定修正を行う
- Nginxの再導入を行う
- rubocopによるコード自動修正を行う

# Why
- AWS/EC2内のインスタンスを変更したため
- NginxをWebサーバとして導入するため

※rubocop済み